### PR TITLE
fix table data not updating if null data

### DIFF
--- a/IronmanCC/src/pages/everything_bingo/EverythingBingo.jsx
+++ b/IronmanCC/src/pages/everything_bingo/EverythingBingo.jsx
@@ -122,6 +122,7 @@ const catButtons = categories
   const handleClick = (skill) => {
     setSelectedTile(skill);
     setSelectedSkill(skill);
+    setSkillData(null);
 
     if (skill === 'Combined Totals') {
       setIsAdminCategory(false);


### PR DESCRIPTION
Turned out to be a rather simple fix.
Each time the user clicks a tile, handleClick in EverythingBingo runs- (its recreating the data for every single tile every time a tile is clicked which is... interesting... but works).
If a clicked skill has data, the state for skillData is set and TableManager is passed skillData- this works as expected on the first click.
But if the next clicked skill has no data, the state for skillData never changes. TableManager is passed a new type but skillData retains its old state and TableManager proceeds as if the old skillData belongs to the new type.
So, resetting the state of skillData back to null as the new click is handled prevents old skillData being passed to TableManager.